### PR TITLE
Fix profiling of custom workload

### DIFF
--- a/profiler.py
+++ b/profiler.py
@@ -18,6 +18,7 @@ DECORATION_LIST = [
     "logistic_regression",
     "micro_benchmarks",
     "poly",
+    "custom_workload",
 ]
 
 


### PR DESCRIPTION
## Summary
- include `custom_workload` in the profiler's decoration list so it is tracked

## Testing
- `PYTHONPATH=$PWD pytest tests` *(fails: ConfigParam missing)*
- `python3 experiment.py`

------
https://chatgpt.com/codex/tasks/task_e_684b3dab7eb08328b71645df93f2c014